### PR TITLE
Support Go 1.17 Setenv()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mitchellh/go-testing-interface
 
-go 1.14
+go 1.17


### PR DESCRIPTION
Closes #10

- Adds `Setenv()` to `T` and `TB` interfaces
- Updates `Parallel()` to panic if `Setenv()` was previously called
- Updates `Cleanup()` to handle multiple cleanup functions (copied from standard library)
- Bumps CI testing and Go module to Go 1.17 to match module compatibility